### PR TITLE
Add one question to React docs

### DIFF
--- a/react/reactjs-quiz.md
+++ b/react/reactjs-quiz.md
@@ -421,3 +421,9 @@ class clock extends React.Component {
 - `useEffect(function updateTitle() { name + ' ' + lastname; });`
 - `useEffect(function updateTitle() { title = name + ' ' + lastname; });`
 
+#### Q44. What can you use to wrap Component imports in order to load them lazily?
+
+- `React.fallback`
+- `React.split`
+- `React.lazy` <<<<<--CORRECT
+- `React.memo`


### PR DESCRIPTION
Added 44th question to React docs.
Q44. What can you use to wrap Component imports in order to load them lazily?

- `React.fallback`
- `React.split`
- `React.lazy` <<<<<--CORRECT
- `React.memo`