### PR TITLE
Fix error s swift-quiz. Add correct answer

### DIFF
--- a/swift/swift-quiz.md
+++ b/swift/swift-quiz.md
@@ -317,7 +317,7 @@ var strings = [1, 2, 3]
 #### Q29. How many times will this loop be executed?
 
 ```swift
-for i in 0..100 {
+for i in 0...100 {
 	print(i)
 }
 ```
@@ -447,5 +447,5 @@ var userLocation: String = "Home" {
 
 - a base class convenience initializer
 - either a designated or another convenience initializer
-- a designated initializer
+- a designated initializer <<<<---Correct
 - none of these answers


### PR DESCRIPTION
Q39: correct the answer [proof](https://docs.swift.org/swift-book/LanguageGuide/Initialization.html#:~:text=A%20convenience%20initializer%20must%20call,ultimately%20call%20a%20designated%20initializer.)

Q29: range operator is `...`, not `..`