### PR TITLE
Changed the option with the correct option

### DIFF
--- a/mongodb/mongodb-quiz.md
+++ b/mongodb/mongodb-quiz.md
@@ -19,7 +19,7 @@
 - [ ] db.citizens.select('WHERE age >= 21')
 - [ ] db.citizens.select('age >= 21')
 - [ ] db.citizens.select('WHERE age >= 21')
-- [x] db.citizens.select({age: {\$qte: 21}})
+- [x] db.citizens.select({age: {\$gte: 21}})
 
 #### Q4. What does a MongoDB collection consist of?
 


### PR DESCRIPTION
Q3. Which shell query displays all citizens with an age greater than or equal to 21?
db.citizens.select('WHERE age >= 21')
db.citizens.select('age >= 21')
db.citizens.select('WHERE age >= 21')
db.citizens.select ({age: {$qte: 21}}) <<<<<----CORRECT

The correct option for the following question is:
db.citizens.select ({age: {$gte: 21}}) <<<<<----CORRECT

Point updated is highlighted or bold marked.